### PR TITLE
Add course landing page for module navigation

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import Introduction from "./components/Introduction";
+import CourseLanding from "./components/CourseLanding";
 import WomensHealthOverview from "./components/WomensHealthOverview";
 import PregnancyBasics from "./components/PregnancyBasics";
 import GTPALSystem from "./components/GTPALSystem";
@@ -38,7 +39,7 @@ import MethodEffectivenessChart from "./components/familyplanning/MethodEffectiv
 import AudioPlayer from "./components/shared/AudioPlayer";
 
 function App() {
-  const [activeModule, setActiveModule] = useState("intro");
+  const [activeModule, setActiveModule] = useState("landing");
   const [completedModules, setCompletedModules] = useState([]);
   const [currentPart, setCurrentPart] = useState(1);
   const [part1ExamResults, setPart1ExamResults] = useState(null);
@@ -46,6 +47,7 @@ function App() {
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
   const part1Modules = [
+    { id: "landing", name: "Course Overview", short: "Overview" },
     { id: "intro", name: "Introduction", short: "Intro" },
     { id: "womenshealth", name: "Women's Health", short: "Women's Health" },
     { id: "basics", name: "Conception & Dating", short: "Conception" },
@@ -110,7 +112,7 @@ function App() {
 
   const switchToPart1 = () => {
     setCurrentPart(1);
-    setActiveModule("intro");
+    setActiveModule("landing");
     setSidebarOpen(false);
   };
 
@@ -314,6 +316,9 @@ function App() {
             {/* Part 1 Modules */}
             {currentPart === 1 && (
               <>
+                {activeModule === "landing" && (
+                  <CourseLanding navigateToModule={navigateToModule} />
+                )}
                 {activeModule === "intro" && (
                   <div className="bg-white rounded-lg shadow-md p-4 sm:p-5 md:p-6 mb-6">
                     <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center border-b pb-4 mb-4">
@@ -321,7 +326,7 @@ function App() {
                         Pregnancy & Birth Learning Module
                       </h2>
                       <span className="bg-indigo-100 text-indigo-800 px-3 py-1 rounded-full text-sm font-medium">
-                        Part 1 - Module 1 of {part1Modules.length}
+                        Part {currentPart} - Module {currentModuleIndex + 1} of {modules.length}
                       </span>
                     </div>
 
@@ -500,7 +505,7 @@ function App() {
                         Postpartum & Newborn Care
                       </h2>
                       <span className="bg-indigo-100 text-indigo-800 px-3 py-1 rounded-full text-sm font-medium">
-                        Part 2 - Module 1 of {part2Modules.length}
+                        Part {currentPart} - Module {currentModuleIndex + 1} of {modules.length}
                       </span>
                     </div>
 

--- a/src/components/CourseLanding.js
+++ b/src/components/CourseLanding.js
@@ -1,0 +1,116 @@
+import React from "react";
+
+const modules = [
+  {
+    id: "module1",
+    title: "Module 1: Current Perspectives in Women's Health and A&P Review",
+    outcomes: [
+      "Explore historical and current childbirth and women's health trends",
+      "Examine factors affecting maternal, newborn, and women's health",
+      "Discuss societal expectations and culture's influence",
+      "Identify healthcare barriers and community resources",
+      "Review reproductive anatomy and physiology"
+    ],
+    link: "womenshealth"
+  },
+  {
+    id: "module1part2",
+    title: "Module 1 Part 2: Fetal Development and Healthy Pregnancy",
+    outcomes: [
+      "Describe conception and implantation processes",
+      "Identify fetal developmental milestones",
+      "Discuss multifetal pregnancy considerations",
+      "Evaluate teratogenic effects",
+      "Apply evidence-based prenatal care principles"
+    ],
+    link: "basics"
+  },
+  {
+    id: "module2",
+    title: "Module 2: Normal Labor and Birth",
+    outcomes: [
+      "Recognize signs of impending labor",
+      "Differentiate between true and false labor",
+      "Analyze factors affecting the labor process",
+      "Evaluate maternal and fetal responses to labor",
+      "Identify and describe the stages of labor"
+    ],
+    link: "labor"
+  },
+  {
+    id: "module3",
+    title: "Module 3: Normal Postpartum",
+    outcomes: [
+      "Explain physiological adaptations during the postpartum period",
+      "Perform comprehensive postpartum assessments",
+      "Provide appropriate patient education",
+      "Enhance maternal-infant bonding and attachment",
+      "Support healthy parenting and family adaptation"
+    ],
+    link: "postpartum"
+  },
+  {
+    id: "module4",
+    title: "Module 4: Normal Newborn",
+    outcomes: [
+      "Describe physiological challenges of newborn transition",
+      "Perform comprehensive newborn assessments",
+      "Recognize normal and abnormal newborn behaviors",
+      "Educate families on newborn safety and screenings",
+      "Implement evidence-based newborn care practices"
+    ],
+    link: "newbornadaptation"
+  },
+  {
+    id: "module5",
+    title: "Module 5: Antepartum at Risk",
+    outcomes: [
+      "Discuss high-risk pregnancy complications",
+      "Apply the nursing process to complex situations",
+      "Identify warning signs and provide patient education",
+      "Analyze risk factors and implement preventive strategies"
+    ],
+    link: "complications"
+  }
+];
+
+const CourseLanding = ({ navigateToModule }) => {
+  return (
+    <div className="bg-white rounded-lg shadow-md p-4 sm:p-5 md:p-6 mb-6">
+      <h2 className="text-xl sm:text-2xl font-bold text-indigo-700 mb-4">
+        Course Overview
+      </h2>
+      <p className="mb-4 text-gray-700">
+        Select a module below to begin exploring course content.
+      </p>
+      <div className="space-y-6">
+        {modules.map((module) => (
+          <div
+            key={module.id}
+            className="border rounded-lg p-4 flex flex-col"
+          >
+            <h3 className="text-lg font-semibold text-indigo-600 mb-2">
+              {module.title}
+            </h3>
+            <ul className="list-disc list-inside mb-4 text-gray-700">
+              {module.outcomes.map((outcome, index) => (
+                <li key={index}>{outcome}</li>
+              ))}
+            </ul>
+            {module.link && (
+              <button
+                onClick={() => navigateToModule(module.link)}
+                className="self-start px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 transition-colors"
+              >
+                Go to Module
+              </button>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default CourseLanding;
+


### PR DESCRIPTION
## Summary
- Introduce course overview landing page with summaries and links for all modules
- Integrate landing page into navigation as initial module and update module indexing

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_688d69bc2c04832cafe33007b792765e